### PR TITLE
Potential fix for code scanning alert no. 475: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gaa.yml
+++ b/.github/workflows/gaa.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - "v1.6.6*"
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gaa/security/code-scanning/475](https://github.com/cooljeanius/gaa/security/code-scanning/475)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `test`) unless overridden. The least-privilege baseline recommended by CodeQL is `contents: read`, which is sufficient for `actions/checkout` in this workflow and does not change intended functionality.

In `.github/workflows/gaa.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the `on:` trigger section (before `jobs:`), so the workflow is explicit and secure by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
